### PR TITLE
Add pulumi-converter-terraform plugin to mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+# Root-level mise.toml to augment .config/mise.toml
+# See https://mise.jdx.dev/configuration.html
+
+[tools]
+# Add pulumi-converter-terraform plugin
+"vfox-pulumi:pulumi/pulumi-converter-terraform" = "1.2.4"


### PR DESCRIPTION
Fixes #565

The upgrade-provider workflow was failing because the pulumi-converter-terraform plugin was not available during SDK generation. This plugin is required for converting Terraform examples to Pulumi examples during make tfgen.

The plugin configuration was previously in .ci-mgmt.yaml (see commit aed2b23) but was removed when ESC was added. Instead of adding it back to .ci-mgmt.yaml, we add it to a root-level mise.toml file which augments the auto-generated .config/mise.toml.